### PR TITLE
Add props `allowNonBiometricMethods` to `authenticate` on iOS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 export type AuthenticateIOS = {
   description?: string;
   fallbackEnabled?: boolean;
+  allowNonBiometricMethods?: boolean;
 };
 export type AuthenticateAndroid = {
   title?: string;
@@ -121,6 +122,7 @@ export interface FingerPrintProps {
       - Returns a `Promise`
       - `description: String` - the string to explain the request for user authentication.
       - `fallbackEnabled: Boolean` - default to ***true***, whether to display fallback button (e.g. Enter Password).
+      - `allowNonBiometricMethods: Boolean` - default to ***false***, whether to allow device owner authentication by non biometric methods (e.g. Passcode, or nearby Apple Watch).
 
       ----------------
       - Example: 

--- a/ios/ReactNativeFingerprintScanner.m
+++ b/ios/ReactNativeFingerprintScanner.m
@@ -55,6 +55,7 @@ RCT_EXPORT_METHOD(isSensorAvailable: (RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(authenticate: (NSString *)reason
                   fallback: (BOOL)fallbackEnabled
+                  allowNonBiometricMethods: (BOOL)allowNonBiometricMethods
                   callback: (RCTResponseSenderBlock)callback)
 {
     LAContext *context = [[LAContext alloc] init];
@@ -64,11 +65,18 @@ RCT_EXPORT_METHOD(authenticate: (NSString *)reason
     if (!fallbackEnabled) {
         context.localizedFallbackTitle = @"";
     }
+    
+    LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+    #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+    if (allowNonBiometricMethods) {
+        policy = LAPolicyDeviceOwnerAuthentication;
+    }
+    #endif
 
     // Device has FingerprintScanner
-    if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
+    if ([context canEvaluatePolicy:policy error:&error]) {
         // Attempt Authentication
-        [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+        [context evaluatePolicy:policy
                 localizedReason:reason
                           reply:^(BOOL success, NSError *error)
          {

--- a/src/authenticate.ios.js
+++ b/src/authenticate.ios.js
@@ -3,9 +3,9 @@ import createError from './createError';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 
-export default ({ description = ' ', fallbackEnabled = true }) => {
+export default ({ description = ' ', fallbackEnabled = true, allowNonBiometricMethods = false }) => {
   return new Promise((resolve, reject) => {
-    ReactNativeFingerprintScanner.authenticate(description, fallbackEnabled, error => {
+    ReactNativeFingerprintScanner.authenticate(description, fallbackEnabled, allowNonBiometricMethods, error => {
       if (error) {
         return reject(createError(error.code, error.message))
       }


### PR DESCRIPTION
Use `LAPolicyDeviceOwnerAuthentication` to allow authentication by non biometric methods.

refs:
https://developer.apple.com/documentation/localauthentication/lapolicy/deviceownerauthenticationwithbiometrics
https://developer.apple.com/documentation/localauthentication/lapolicy/deviceownerauthentication