### PR TITLE
Support non biometric authentication on Android

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ export type AuthenticateAndroid = {
   subTitle?: string;
   description?: string;
   cancelButton?: string;
+  allowNonBiometricMethods?: boolean;
   onAttempt?: (error: FingerprintScannerError) => void;
 };
 
@@ -140,10 +141,11 @@ export interface FingerPrintProps {
       ```
       -----------------
 
-      ### authenticate({ description: 'Log in with Biometrics', onAttempt: () => (null) }): (Android)
+      ### authenticate({ description: 'Log in with Biometrics', allowNonBiometricMethods: true, onAttempt: () => (null) }): (Android)
 
       - Returns a `Promise`
       - `description: String` - the title text to appear on the native Android prompt
+      - `allowNonBiometricMethods: Boolean` - default to ***false***, whether to allow device owner authentication by non biometric methods (e.g. PIN, or nearby Apple Watch).
       - `onAttempt: Function` - a callback function when users are trying to scan their fingerprint but failed.
 
       -----------------
@@ -152,6 +154,7 @@ export interface FingerPrintProps {
       FingerprintScanner
         .authenticate({
           description: 'Log in with Biometrics',
+          allowNonBiometricMethods: true,
           onAttempt: this.handleAuthenticationAttempted,
         })
         .then(() => {

--- a/src/authenticate.android.js
+++ b/src/authenticate.android.js
@@ -7,8 +7,8 @@ import createError from './createError';
 
 const { ReactNativeFingerprintScanner } = NativeModules;
 
-const authCurrent = (title, subTitle, description, cancelButton, resolve, reject) => {
-  ReactNativeFingerprintScanner.authenticate(title, subTitle, description, cancelButton)
+const authCurrent = (title, subTitle, description, cancelButton, allowNonBiometricMethods, resolve, reject) => {
+  ReactNativeFingerprintScanner.authenticate(title, subTitle, description, cancelButton, allowNonBiometricMethods)
     .then(() => {
       resolve(true);
     })
@@ -38,7 +38,7 @@ const authLegacy = (onAttempt, resolve, reject) => {
 
 const nullOnAttempt = () => null;
 
-export default ({ title, subTitle, description, cancelButton, onAttempt }) => {
+export default ({ title, subTitle, description, cancelButton, allowNonBiometricMethods = false, onAttempt }) => {
   return new Promise((resolve, reject) => {
     if (!title) {
       title = description ? description : "Log In";
@@ -61,6 +61,6 @@ export default ({ title, subTitle, description, cancelButton, onAttempt }) => {
       return authLegacy(onAttempt, resolve, reject);
     }
 
-    return authCurrent(title, subTitle, description, cancelButton, resolve, reject);
+    return authCurrent(title, subTitle, description, cancelButton, allowNonBiometricMethods, resolve, reject);
   });
 }


### PR DESCRIPTION
- Supports non biometric authentication on Android.
  - e.g. Pattern lock, PIN or password
- Enable it by specifying `allowNonBiometricMethods` to true.
- Note that cancel button text would not be set if non biometric methods enabled, for it would be overridden to `USE PASSWORD` or something like that by system OS.

---

refs:
https://developer.android.com/reference/androidx/biometric/BiometricPrompt.PromptInfo.Builder#setDeviceCredentialAllowed(boolean)
https://developer.android.com/reference/androidx/biometric/BiometricPrompt.PromptInfo.Builder#setNegativeButtonText(java.lang.CharSequence)
